### PR TITLE
style: extract pricing note

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -58,7 +58,7 @@
       </table>
     </div>
     <a href="signup.html" class="cta-btn">Try a Free Class</a>
-    <p style="margin-top:1.3rem;font-size:1rem;color:#ff6600;">Family discounts and day passes available—ask at the front desk!</p>
+    <p class="pricing-note">Family discounts and day passes available—ask at the front desk!</p>
   </div>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -41,7 +41,13 @@
     margin-bottom: 2rem;
     line-height: 1.6;
   }
-  
+
+  .pricing-note {
+    margin-top: 1.3rem;
+    font-size: 1rem;
+    color: var(--main-orange);
+  }
+
   /* ---------------------- */
   /* Navbar Styles */
   /* ---------------------- */


### PR DESCRIPTION
## Summary
- replace inline pricing note style with reusable `pricing-note` class
- add `.pricing-note` styling for orange text and spacing

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_689e0dfd6f008325bb475a76f652d816